### PR TITLE
SWIG 4.1.0 flat static patch

### DIFF
--- a/recipe/0004-swig410-flatstatic.patch
+++ b/recipe/0004-swig410-flatstatic.patch
@@ -1,0 +1,11 @@
+--- a/More/python/Makefile.in	2023-02-13 18:27:51.000000000 -0700
++++ b/More/python/Makefile.in	2023-02-13 18:28:23.000000000 -0700
+@@ -470,7 +470,7 @@
+                       $(top_builddir)/Util/epsic/src/libepsic.la \
+                       @PYTHON_LDFLAGS@ 
+ 
+-SWIG_FLAGS = -Wall -python -I$(top_builddir)/local_include -I$(top_builddir)
++SWIG_FLAGS = -Wall -python -flatstaticmethod -I$(top_builddir)/local_include -I$(top_builddir)
+ local_includedir = $(top_builddir)/local_include
+ LOCAL_INCLUDE = $(addprefix $(local_includedir)/, $(HEADERS))
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,11 @@ source:
   # e.g., https://sourceforge.net/projects/psrchive/files/psrchive/2021-01-18/psrchive-2021-01-18.tar.gz/download
   url: https://sourceforge.net/projects/{{ name }}/files/{{ name }}/{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+      - 0004-swig410-flatstatic.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win or (python_impl == 'pypy')]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,14 +49,15 @@ requirements:
     - fftw
     - readline
 test:
+  imports:
+    - psrchive
   files:
     - test_data/example_psrfits.fits
   commands:
     - pav -h
     - pam -T -e T test_data/example_psrfits.fits
     - test -f test_data/example_psrfits.T
-  imports:
-    - psrchive
+    - python -c "import psrchive; psrchive.Archive_load('test_data/example_psrfits.fits')"
 
 about:
   home: http://psrchive.sourceforge.net/


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

SWIG 4.1.0 removes creation of static class member functions in the main namespace, breaking backwards compatibility for common usage like `psrchive.Archive_load()`.  This patch re-enables the old behavior and adds a relevant test.  See https://sourceforge.net/p/psrchive/bugs/475/ for more info.

<!--
Please add any other relevant info below:
-->
